### PR TITLE
lib/context: fix ownership problems in req_tgs

### DIFF
--- a/libkrb5/src/principal.rs
+++ b/libkrb5/src/principal.rs
@@ -22,6 +22,18 @@ impl<'a> Drop for Krb5Principal<'a> {
 }
 
 impl<'a> Krb5Principal<'a> {
+    pub fn new_from_raw(context: &Krb5Context, raw_principal: krb5_principal) -> Result<Krb5Principal, Krb5Error> {
+        let mut out_principal: MaybeUninit<krb5_principal> = MaybeUninit::zeroed();
+        let code = unsafe { krb5_copy_principal(context.context, raw_principal, out_principal.as_mut_ptr()) };
+        krb5_error_code_escape_hatch(context, code)?;
+
+        let out_principal = Krb5Principal {
+            context,
+            principal: unsafe { out_principal.assume_init() },
+        };
+        Ok(out_principal)
+    }
+
     pub fn data(&self) -> Krb5PrincipalData {
         Krb5PrincipalData {
             context: &self.context,


### PR DESCRIPTION
This patch fixes two problems:
1) Assignment of the inner buffer of `second_ticket` as a mutable pointer
   to `in_creds.creds.second_ticket.data` is unsound, since req_tgs only
   has an inmutable reference to it. This will result in having multiple
   mutable references to the same memory.
2) Assigning the inner mutable krb5_principal pointer of `principal` to
   `in_creds` is also unsound for the same reason.