### PR TITLE
libkrb5/src/ccache.rs: use in memory ccache

### DIFF
--- a/libkrb5/src/ccache.rs
+++ b/libkrb5/src/ccache.rs
@@ -18,7 +18,7 @@ pub struct Krb5CCache<'a> {
 impl<'a> Drop for Krb5CCache<'a> {
     fn drop(&mut self) {
         unsafe {
-            krb5_cc_close(self.context.context, self.ccache);
+            krb5_cc_destroy(self.context.context, self.ccache);
         }
     }
 }

--- a/libkrb5/src/context.rs
+++ b/libkrb5/src/context.rs
@@ -286,7 +286,7 @@ impl Krb5Context {
 
         in_creds.creds.second_ticket = data;
 
-        let mut ccache: Krb5CCache = Krb5CCache::default(&self)?;
+        let mut ccache: Krb5CCache = Krb5CCache::new_unique(&self, "MEMORY")?;
         {
             let principal: Krb5Principal = in_creds.get_client_principal()?;
             ccache.initialize(&principal)?;


### PR DESCRIPTION
- built up ccache in MEMORY
- generate a unique ccache for each context
- destroy ccache entirely